### PR TITLE
Update README to match current pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,65 @@
-# Generate an image for the [TRMNL](https://usetrmnl.com/) display.
+# Zonneplan → TRMNL
 
-This image can be used with the [Image display](https://usetrmnl.com/plugin_settings?keyname=image_display) or [Alias](https://usetrmnl.com/plugin_settings?keyname=alias) plugin
+Generates an e-ink-ready image of Zonneplan's hourly dynamic electricity prices for the [TRMNL](https://usetrmnl.com/) display. Use the rendered PNG/BMP with the TRMNL [Image display](https://usetrmnl.com/plugin_settings?keyname=image_display) or [Alias](https://usetrmnl.com/plugin_settings?keyname=alias) plugin.
 
 ![](https://leipeleon.github.io/zonneplan/diffused.png)
 
-- dithered png: <https://leipeleon.github.io/zonneplan/dithered.png>
-- diffused png: <https://leipeleon.github.io/zonneplan/diffused.png>
-- diffused bmp: <https://leipeleon.github.io/zonneplan/diffused.bmp>
-- color: <https://leipeleon.github.io/zonneplan/hours.png>
+## Published outputs
 
-1. Make a screenshot of https://www.zonneplan.nl/energie/dynamische-energieprijzen
-2. crop out the graphic w/ imagemagick
-3. create a [diffused image](https://leipeleon.github.io/zonneplan/diffused.png)
-4. Upload it to github-pages
-5. PROFIT!
+The hourly GitHub Actions workflow publishes the latest images to GitHub Pages:
 
-## Further reading for investigation
+- Color chart: <https://leipeleon.github.io/zonneplan/hours.png>
+- Dithered PNG: <https://leipeleon.github.io/zonneplan/dithered.png>
+- 1-bit PNG (for TRMNL): <https://leipeleon.github.io/zonneplan/diffused.png>
+- 1-bit BMP (for TRMNL): <https://leipeleon.github.io/zonneplan/diffused.bmp>
+- Rendered README: <https://leipeleon.github.io/zonneplan/>
 
-- https://help.usetrmnl.com/en/articles/11479051-image-display
-- https://docs.usetrmnl.com/go/imagemagick-guide
-- https://usage.imagemagick.org/crop/#crop
+## How it works
 
+1. **Fetch.** Scrape <https://www.zonneplan.nl/energie/dynamische-energieprijzen>, scanning the streamed Next.js chunks (`self.__next_f.push([...])`) for `ElectricityHour` objects.
+2. **Fallback.** If no `ElectricityHour` records turn up, fall back to the EnergyZero public API (`https://api.energyzero.nl/v1/energyprices`). Pricing profile (`low` / `normal` / `high`) is then classified by quartile bucketing across the day's prices.
+3. **Tabulate.** Write a gnuplot data file with the price split into stacked components — market price, handling fee, energy taxes — plus the profile color and a label on the day's min/max boundary hours. Past hours (older than ~1h) are greyed out; anything older than 4h is dropped.
+4. **Plot.** Render an 800×480 PNG via gnuplot — that's the TRMNL display resolution.
+5. **Dither.** Run it through ImageMagick: Floyd–Steinberg + ordered dither → 1-bit monochrome PNG and BMP.
 
-## Scrape site
+Raw price fields (`priceTotalTaxIncluded`, `marketPrice`, `priceEnergyTaxes`, `priceInclHandlingVat`) are integers; divide by `Zonneplan::PRICE_DIVISOR` (`100_000`) to get EUR/kWh.
 
-Content is in `<script id="__NEXT_DATA__" type="application/json">`
--> "props.pageProps.data.templateProps.energyData.electricity.hours[]"
+## Automation
 
-divide element values by 100000
+`.github/workflows/build.yml` runs on push to `main`, PRs, manual dispatch, and an hourly cron (`5 * * * *`). Each run:
 
-```json
-{
-  "props": {
-    "pageProps": {
-      "data": {
-        "templateProps" : {
-          "energyData": {
-            "__typename": "EnergyData",
-            "electricity": {
-              "__typename": "Electricity",
-              "hours": [
-                {
-                  "__typename": "ElectricityHour",
-                  "dateTime": "2025-05-31T21:00:00.000000Z",
-                  "priceTotalTaxIncluded": 2636093,
-                  "marketPrice": 997900,
-                  "priceInclHandlingVat": 1407459,
-                  "priceEnergyTaxes": 1228634,
-                  "priceCbsAverage": 0.4,
-                  "pricingProfile": "normal"
-                },
-                {
-                  // ....
-                }
-              ]
-            }
-          },
-        }
-      }
-    }
-  }
-}
+- Installs `gnuplot-nox` + `imagemagick` (apt archives cached between runs).
+- Executes `./script/build`.
+- Renders this README via the GitHub Markdown API into `build/index.html`.
+- Archives `hours.png` and `hours.dat` under `history/YYYY/MM/DD-HHMM*` and commits the snapshot back to `main`.
+- Deploys `build/` to GitHub Pages.
+
+## Running locally
+
+Prerequisites:
+
+```sh
+brew install gnuplot imagemagick    # Ruby 3.3 also required
 ```
+
+Then:
+
+```sh
+./script/build
+```
+
+Outputs land in `build/`. The script forces `TZ=Europe/Amsterdam` so the chart aligns with Dutch wall-clock time regardless of host TZ.
+
+## Tests
+
+```sh
+bundle exec rspec
+```
+
+RSpec + WebMock with fixtures under `spec/fixtures/`.
+
+## Further reading
+
+- <https://help.usetrmnl.com/en/articles/11479051-image-display>
+- <https://docs.usetrmnl.com/go/imagemagick-guide>
+- <https://usage.imagemagick.org/crop/#crop>

--- a/README.md
+++ b/README.md
@@ -8,19 +8,20 @@ Generates an e-ink-ready image of Zonneplan's hourly dynamic electricity prices 
 
 The hourly GitHub Actions workflow publishes the latest images to GitHub Pages:
 
-- Color chart: <https://leipeleon.github.io/zonneplan/hours.png>
 - Dithered PNG: <https://leipeleon.github.io/zonneplan/dithered.png>
 - 1-bit PNG (for TRMNL): <https://leipeleon.github.io/zonneplan/diffused.png>
 - 1-bit BMP (for TRMNL): <https://leipeleon.github.io/zonneplan/diffused.bmp>
 - Rendered README: <https://leipeleon.github.io/zonneplan/>
+
+The raw gnuplot render (`hours.png`) and its data file (`hours.dat`) aren't published — each run is archived under [`history/YYYY/MM/`](history/) instead.
 
 ## How it works
 
 1. **Fetch.** Scrape <https://www.zonneplan.nl/energie/dynamische-energieprijzen>, scanning the streamed Next.js chunks (`self.__next_f.push([...])`) for `ElectricityHour` objects.
 2. **Fallback.** If no `ElectricityHour` records turn up, fall back to the EnergyZero public API (`https://api.energyzero.nl/v1/energyprices`). Pricing profile (`low` / `normal` / `high`) is then classified by quartile bucketing across the day's prices.
 3. **Tabulate.** Write a gnuplot data file with the price split into stacked components — market price, handling fee, energy taxes — plus the profile color and a label on the day's min/max boundary hours. Past hours (older than ~1h) are greyed out; anything older than 4h is dropped.
-4. **Plot.** Render an 800×480 PNG via gnuplot — that's the TRMNL display resolution.
-5. **Dither.** Run it through ImageMagick: Floyd–Steinberg + ordered dither → 1-bit monochrome PNG and BMP.
+4. **Plot.** Render an 800×480 monochrome PNG via gnuplot (`set mono`, greyscale fill patterns for the stacked components) — that's the TRMNL display resolution.
+5. **Dither.** Run it through ImageMagick: Floyd–Steinberg + ordered dither → 1-bit PNG and BMP.
 
 Raw price fields (`priceTotalTaxIncluded`, `marketPrice`, `priceEnergyTaxes`, `priceInclHandlingVat`) are integers; divide by `Zonneplan::PRICE_DIVISOR` (`100_000`) to get EUR/kWh.
 


### PR DESCRIPTION
## Summary

- Rewrite README to match the current automated pipeline: scrape streamed Next.js payloads (`self.__next_f.push(...)`) with EnergyZero API fallback, gnuplot render, ImageMagick dither to 1-bit PNG/BMP for the TRMNL display.
- Document the GitHub Actions cron, `history/` archival, GitHub Pages deploy, local-run prerequisites (`brew install gnuplot imagemagick`), and the `bundle exec rspec` test command.
- Drop the obsolete "screenshot + crop" steps and the stale `__NEXT_DATA__` JSON example.
- Correct the published-outputs list: `hours.png` is greyscale (gnuplot `set mono`) and is moved into `history/` before deploy, so only `dithered.png`, `diffused.png`, and `diffused.bmp` are actually on Pages.

## Test plan

- [ ] Open the rendered README on Pages after merge and confirm every link resolves.
- [ ] Verify `./script/build` locally still produces `build/diffused.png` and `build/diffused.bmp` as described.
